### PR TITLE
use Compat for v0.4 Dict syntax

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.3-
+Compat

--- a/src/ReverseDiffSource.jl
+++ b/src/ReverseDiffSource.jl
@@ -10,6 +10,9 @@ module ReverseDiffSource
   
   import Base.show, Base.copy
 
+  # Julia v0.3, v0.4 syntax compatibility issues
+  using Compat
+
   # naming conventions
   const TEMP_NAME = "_tmp"   # prefix of new variables
   const DERIV_PREFIX = "d"   # prefix of gradient variables

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -363,7 +363,7 @@ function calc!(g::ExGraph; params=Dict(), emod = Main)
     iter = evaluate(n.parents[1])           #  myeval(n.main[1].args[2])
     # is0 = next(iter, start(iter))[2]        # first value of index
     is0 = first(iter)                       # first value of index
-    params2 = merge(params, Dict( is => is0 ))  # set loop index to first value
+    params2 = merge(params, @compat Dict( is => is0 ))  # set loop index to first value
     # println("params2 : $(params2)")
     calc!(g2, params=params2)
     

--- a/src/rdiff.jl
+++ b/src/rdiff.jl
@@ -164,13 +164,13 @@ function rdiff(ex; outsym=nothing, order::Int=1, evalmod=Main, debug=false, para
             nf = addnode!(g, NFor(Any[ si, dg ] ) )
 
             # create param size node
-            nsz = addgraph!( :( length( x ) ), g, Dict( :x => getnode(g.exti, paramsym[1]) ) )
+            nsz = addgraph!( :( length( x ) ), g, @compat Dict( :x => getnode(g.exti, paramsym[1]) ) )
 
             # create (n-1)th derivative size node
-            ndsz = addgraph!( :( sz ^ $(i-1) ), g, Dict( :sz => nsz ) )
+            ndsz = addgraph!( :( sz ^ $(i-1) ), g, @compat Dict( :sz => nsz ) )
 
             # create index range node
-            nid = addgraph!( :( 1:dsz ),  g, Dict( :dsz => ndsz ) )
+            nid = addgraph!( :( 1:dsz ),  g, @compat Dict( :dsz => ndsz ) )
             push!(nf.parents, nid)
 
             # pass size node inside subgraph
@@ -181,7 +181,7 @@ function rdiff(ex; outsym=nothing, order::Int=1, evalmod=Main, debug=false, para
             push!(nf.parents, nsz)
 
             # create result node (alloc in parent graph)
-            nsa = addgraph!( :( zeros( $( Expr(:tuple, [:sz for j in 1:i]...) ) ) ), g, Dict( :sz => nsz ) )
+            nsa = addgraph!( :( zeros( $( Expr(:tuple, [:sz for j in 1:i]...) ) ) ), g, @compat Dict( :sz => nsz ) )
             ssa = newvar()
             insa = addnode!(dg, NExt(ssa))
             dg.exti[insa] = ssa
@@ -190,10 +190,10 @@ function rdiff(ex; outsym=nothing, order::Int=1, evalmod=Main, debug=false, para
 
             # create result node update (in subgraph)
             nres = addgraph!( :( res[ ((sidx-1)*st+1):(sidx*st) ] = dx ; res ), dg, 
-                                Dict(   :res  => insa,
-                                        :sidx => nmap[ni],
-                                        :st   => inst,
-                                        :dx   => collect(dg.seti)[1][1] ) )
+                                @compat Dict(:res  => insa,
+                                             :sidx => nmap[ni],
+                                             :st   => inst,
+                                             :dx   => collect(dg.seti)[1][1] ) )
             dg.seti = NSMap([nres], [ssa])
 
             # create exit node for result

--- a/src/reversegraph.jl
+++ b/src/reversegraph.jl
@@ -37,7 +37,7 @@ function createzeronode!(g2::ExGraph, n)
 	if method_exists(d_equivnode_1, (typeof(n.val),) )
 		rn = invoke(d_equivnode_1, (typeof(n.val),) , n.val)
     	dg, dd, de = rdict[ rn ]
-    	smap = Dict( dd[1] => n )  # map 'x' node to n
+    	smap = @compat Dict( dd[1] => n )  # map 'x' node to n
     	exitnode = addgraph!(dg, g2, smap)
 
     	return exitnode
@@ -46,7 +46,7 @@ function createzeronode!(g2::ExGraph, n)
 	elseif (isa(n.val, Array) || isa(n.val, Tuple)) && method_exists(d_equivnode_1, (eltype(n.val),) )
 		rn = invoke(d_equivnode_1, (eltype(n.val),) , n.val[1])
     	dg, dd, de = rdict[ rn ]
-    	smap = Dict( dd[1] => n )  # map 'x' node to n
+    	smap = @compat Dict( dd[1] => n )  # map 'x' node to n
     	exitnode = addgraph!(dg, g2, smap)
 
     	v1 = addnode!(g2, NCall(:size, [n]))
@@ -212,7 +212,7 @@ function reversepass!(g2::ExGraph, g::ExGraph, dnodes::Dict)
 		# println("after pruning\n$fg")
 
 		# create for loop
-		nr = addgraph!( :( reverse( x ) ), g2, Dict( :x => n.parents[1] ) ) # range in reverse order
+		nr = addgraph!( :( reverse( x ) ), g2, @compat Dict( :x => n.parents[1] ) ) # range in reverse order
 		v2 = addnode!(g2, NFor(Any[ n.main[1], fg ]) )
 		v2.parents = [nr, collect( nodes( fg.exto)) ]
 


### PR DESCRIPTION
I noticed this package wasn't working on Julia 0.3 due to the use of the 0.4 Dict syntax 
This is a quick fix using the macros from the Compat package to wrap the new syntax.
